### PR TITLE
fix: fixed getChild method of ParserRuleContext class

### DIFF
--- a/src/ParserRuleContext.ts
+++ b/src/ParserRuleContext.ts
@@ -161,7 +161,10 @@ export class ParserRuleContext extends RuleContext {
     public override getChild<T extends ParseTree>(i: number,
         type: new (parent: ParserRuleContext | null, invokingStateNumber: number) => T): T | null;
     public override getChild<T extends ParseTree>(i: number,
-        type?: new (parent: ParserRuleContext | null, invokingStateNumber: number) => T): T | null {
+        type: new (symbol: Token) => T): T | null;
+    public override getChild<T extends ParseTree>(i: number,
+        type?: (new (parent: ParserRuleContext | null, invokingStateNumber: number) => T)
+            | (new (symbol: Token) => T)): T | null {
         if (this.children === null || i < 0 || i >= this.children.length) {
             return null;
         }

--- a/src/ParserRuleContext.ts
+++ b/src/ParserRuleContext.ts
@@ -159,12 +159,9 @@ export class ParserRuleContext extends RuleContext {
 
     public override getChild(i: number): RuleContext | null;
     public override getChild<T extends ParseTree>(i: number,
-        type: new (parent: ParserRuleContext | null, invokingStateNumber: number) => T): T | null;
+        type: new (...args: unknown[]) => T): T | null;
     public override getChild<T extends ParseTree>(i: number,
-        type: new (symbol: Token) => T): T | null;
-    public override getChild<T extends ParseTree>(i: number,
-        type?: (new (parent: ParserRuleContext | null, invokingStateNumber: number) => T)
-            | (new (symbol: Token) => T)): T | null {
+        type?: new (...args: unknown[]) => T): T | null {
         if (this.children === null || i < 0 || i >= this.children.length) {
             return null;
         }


### PR DESCRIPTION
## Problem
- I'm porting my code from the Java `antlr4-runtime` and TS `antlr4ts` libraries. In these libraries, the `getChild` method of class `ParserRuleContext` take a type that implements both TerminalNode and ParserRuleContext.
- `antlr-4ng` allows you to pass a type that implements only `ParserRuleContext`.
- This significantly complicates code porting because the library's API differs from its analogues.
## Сomparison of libraries
### TS `antlr-4ng`
class `ParserRuleContext` have mthod `getChild` with declaration
```ts
getChild<T extends ParseTree>(i: number, type: new (parent: ParserRuleContext | null, invokingStateNumber: number) => T): T | null;
```
### TS `antlr4ts`
class `ParserRuleContext` have mthod `getChild` with declaration
```ts
public getChild<T extends ParseTree>(i: number, ctxType: { new (...args: any[]): T; }): T;
```
### Java `antlr4-runtime`
class `ParserRuleContext` have mthod `getChild` with declaration
```java
public <T extends ParseTree> T getChild(Class<? extends T> ctxType, int i);
```
### Conclusion
- I assume that the reference implementation for all libraries is the Java implementation. Because method `getChild`  in Java take `ParseTree` interface, I think that your library should provide this too
- Due to the fact that in TS it is not possible to pass the interface type as a function argument, `antlr4ts` library method take the node type argument, casting it to the constructor type with argument - varargs of any (`...args: any[]`)
- I assume that the `antlr-4ng` library does not use the `any` type. Because of this, the `getChild` method takes the `ParserRuleContext` class constructor as its second argument
## Comparison of node constructors in `antlr-4ng`
Let's look at the constructors of all classes that implement the `ParseTree` interface
### `ParserRuleContext`
Class `ParserRuleContext` extend `RuleContext` which implement `ParseTree`
```ts
class ParserRuleContext extends RuleContext {

  constructor(parent: ParserRuleContext | null, invokingStateNumber: number);
  constructor(parent: ParserRuleContext | null, invokingStateNumber?: number);
  ...
}
```
### `TerminalNode`
Class `TerminalNode` implements `ParseTree`
```ts
class TerminalNode implements ParseTree {

  constructor(symbol: Token);
  ...
}
```
### `ErrorNode`
Class `ErrorNode` extends `TerminalNode` and inherits its constructor
```ts
class ErrorNode extends TerminalNode {
  ...
}
```
### Conclusion
- From the comparison it is clear that of all the classes that implement `ParseTree` interface, the `getChild` method does not accept only `TerminalNode` and `ErrorNode` classes
- Сlasses `TerminalNode` and `ErrorNode` have the same constructor: `constructor(symbol: Token);`

## Proposed changes
- From the above it follows that it is necessary to add support for an argument with the constructor type `new (symbol: Token) => T` to the `getChild` method of `ParserRuleContext` class.