### PR TITLE
Improve HashSet performance for specific Grammars

### DIFF
--- a/src/misc/HashMap.ts
+++ b/src/misc/HashMap.ts
@@ -9,18 +9,18 @@ import { EqualsFunction, HashFunction } from "./HashSet.js";
 
 interface Entry<Key extends IComparable, Value> { key: Key, value: Value; }
 
-export class HashMap<Key extends IComparable, Value> {
-    private data: { [key: string]: Array<Entry<Key, Value>>; };
-    private hashFunction: HashFunction;
-    private equalsFunction: EqualsFunction;
+export class HashMap<TKey extends IComparable, TValue> {
+    private data: Record<string, Entry<TKey, TValue>[]>;
+    private hashFunction: HashFunction<TKey>;
+    private equalsFunction: EqualsFunction<TKey>;
 
-    public constructor(hashFunction?: HashFunction, equalsFunction?: EqualsFunction) {
+    public constructor(hashFunction?: HashFunction<TKey>, equalsFunction?: EqualsFunction<TKey>) {
         this.data = {};
         this.hashFunction = hashFunction ?? standardHashCodeFunction;
         this.equalsFunction = equalsFunction ?? standardEqualsFunction;
     }
 
-    public set(key: Key, value: Value): Value {
+    public set(key: TKey, value: TValue): TValue {
         const hashKey = this.hashFunction(key);
         if (hashKey in this.data) {
             const entries = this.data[hashKey];
@@ -42,7 +42,7 @@ export class HashMap<Key extends IComparable, Value> {
         }
     }
 
-    public containsKey(key: Key): boolean {
+    public containsKey(key: TKey): boolean {
         const hashKey = this.hashFunction(key);
         if (hashKey in this.data) {
             const entries = this.data[hashKey];
@@ -56,7 +56,7 @@ export class HashMap<Key extends IComparable, Value> {
         return false;
     }
 
-    public get(key: Key): Value | null {
+    public get(key: TKey): TValue | null {
         const hashKey = this.hashFunction(key);
         if (hashKey in this.data) {
             const entries = this.data[hashKey];
@@ -70,17 +70,17 @@ export class HashMap<Key extends IComparable, Value> {
         return null;
     }
 
-    public entries(): Array<Entry<Key, Value>> {
+    public entries(): Array<Entry<TKey, TValue>> {
         return Object.keys(this.data).flatMap((key) => {
             return this.data[key];
         }, this);
     }
 
-    public getKeys(): Key[] {
+    public getKeys(): TKey[] {
         return this.entries().map((e) => { return e.key; });
     }
 
-    public getValues(): Value[] {
+    public getValues(): TValue[] {
         return this.entries().map((e) => { return e.value; });
     }
 

--- a/src/misc/HashSet.ts
+++ b/src/misc/HashSet.ts
@@ -45,16 +45,11 @@ export class HashSet<T extends IComparable> {
     }
 
     public has(value: T): boolean {
-        return this.get(value) != null;
+        return this.get(value) !== null;
     }
 
     public get(value: T): T | null {
-        const key = this.hashFunction(value);
-        const entries = this.#data[key];
-        if (entries) {
-            return entries.find((entry) => this.equalsFunction(value, entry)) ?? null;
-        }
-        return null;
+        return this.#data[this.hashFunction(value)]?.find((entry) => this.equalsFunction(value, entry)) ?? null;
     }
 
     public values(): T[] {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -12,7 +12,7 @@ export interface IComparable<T = unknown> {
 
 function isComparable(candidate: unknown): candidate is IComparable {
     return typeof (candidate as IComparable).equals === "function";
-}
+};
 
 /**
  * @param value The array to stringify.

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -19,7 +19,7 @@ function isComparable(candidate: unknown): candidate is IComparable {
  *
  * @returns a human readable string of an array (usually for debugging and testing).
  */
-export const arrayToString = (value: unknown): string => {
+export function arrayToString(value: unknown): string {
     return Array.isArray(value) ? `[${value.map(v => String(v)).join(", ")}]` : String(value);
 };
 
@@ -31,7 +31,7 @@ export const arrayToString = (value: unknown): string => {
  *
  * @returns `true` if `a` and `b` are equal.
  */
-export const equalArrays = (a: unknown[], b: unknown[]): boolean => {
+export function equalArrays(a: unknown[], b: unknown[]): boolean {
     if (a === b) {
         return true;
     }
@@ -47,7 +47,7 @@ export const equalArrays = (a: unknown[], b: unknown[]): boolean => {
             continue;
         }
 
-        if (isComparable(left) && !left.equals(right)) {
+        if (!isComparable(left) || !left.equals(right)) {
             return false;
         }
     }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -5,26 +5,22 @@
  */
 
 /** Expresses the Java concept of object equality (equality based on the content of two objects). */
-export interface IComparable {
-    equals(obj: unknown): boolean;
+export interface IComparable<T = unknown> {
+    equals(obj: T | null): boolean;
     hashCode(): number;
 }
 
-const isComparable = (candidate: unknown): candidate is IComparable => {
+function isComparable(candidate: unknown): candidate is IComparable {
     return typeof (candidate as IComparable).equals === "function";
-};
-
-const valueToString = (v: null | string): string => {
-    return v === null ? "null" : v;
-};
+}
 
 /**
  * @param value The array to stringify.
  *
  * @returns a human readable string of an array (usually for debugging and testing).
  */
-export const arrayToString = (value: unknown[] | null): string => {
-    return Array.isArray(value) ? ("[" + value.map(valueToString).join(", ") + "]") : "null";
+export const arrayToString = (value: unknown): string => {
+    return Array.isArray(value) ? `[${value.map(v => String(v)).join(", ")}]` : String(value);
 };
 
 /**
@@ -85,7 +81,7 @@ export const escapeWhitespace = (s: string, escapeSpaces = false): string => {
  * @returns `true` if `a` and `b` are equal.
  */
 export const standardEqualsFunction = (a: IComparable | null, b: unknown): boolean => {
-    return a ? a.equals(b) : a === b;
+    return a === b || !!a?.equals(b);
 };
 
 const stringSeedHashCode = Math.round(Math.random() * Math.pow(2, 32));

--- a/tests/helpers.spec.ts
+++ b/tests/helpers.spec.ts
@@ -1,0 +1,42 @@
+import { IComparable, equalArrays } from '../src/utils/helpers.js';
+
+// A custom class that implements IComparable for testing purposes.
+class Comparable implements IComparable<Comparable> {
+    constructor(public value: string | number | null) { }
+    equals(obj: Comparable | null): boolean {
+        return obj ? this.value == obj?.value : false;
+    }
+    hashCode(): number { return this.value ? Number(this.value) : 0; }
+}
+
+describe('equalArrays', () => {
+    it('should return true for equal arrays', () => {
+        const arr1 = [1, 2, 3];
+        const arr2 = [1, 2, 3];
+        expect(equalArrays(arr1, arr2)).toBe(true);
+    });
+
+    it('should return false for arrays with different lengths', () => {
+        const arr1 = [1, 2, 3];
+        const arr2 = [1, 2];
+        expect(equalArrays(arr1, arr2)).toBe(false);
+    });
+
+    it('should return false for arrays with different elements', () => {
+        const arr1 = [1, 2, 3];
+        const arr2 = [1, 4, 3];
+        expect(equalArrays(arr1, arr2)).toBe(false);
+    });
+
+    it('should return true for arrays with custom objects that have an equals method', () => {
+        const arr1 = [ new Comparable(1) ];
+        const arr2 = [ new Comparable("1") ];
+        expect(equalArrays(arr1, arr2)).toBe(true);
+    });
+
+    it('should return false for arrays with custom objects that have different equals method results', () => {
+        const arr1 = [ new Comparable(1) ];
+        const arr2 = [ new Comparable("2") ];
+        expect(equalArrays(arr1, arr2)).toBe(false);
+    });
+});

--- a/tests/utils/HashSet.spec.ts
+++ b/tests/utils/HashSet.spec.ts
@@ -1,0 +1,136 @@
+import { HashSet } from '../../src/misc/HashSet.js';
+import { IComparable } from '../../src/utils/helpers.js';
+
+// A custom class that implements IComparable for testing purposes.
+class Comparable implements IComparable<Comparable> {
+    constructor(public value: string | number | null) { }
+    equals(obj: Comparable | null): boolean {
+        return obj ? this.value == obj?.value : false;
+    }
+    hashCode(): number { return this.value ? Number(this.value) : 0; }
+    toString(): string { return String(this.value); }
+}
+
+describe('HashSet', () => {
+
+    describe("add", () => {
+        it('should add unique IComparable values to the set', () => {
+            const set = new HashSet<Comparable>();
+            const value1 = new Comparable(1);
+            const value2 = new Comparable(2);
+
+            set.add(value1);
+            set.add(value2);
+
+            expect(set.length).toBe(2);
+            expect(set.has(value1)).toBe(true);
+            expect(set.has(value2)).toBe(true);
+        });
+
+        it('should not add duplicate IComparable values to the set', () => {
+            const set = new HashSet<Comparable>();
+            const value1 = new Comparable(1);
+            const value2 = new Comparable(1);
+
+            set.add(value1);
+            set.add(value2);
+
+            expect(set.length).toBe(1);
+            expect(set.has(value1)).toBe(true);
+            expect(set.has(value2)).toBe(true);
+            expect(set.add(value2)).toStrictEqual(value1);
+        });
+
+        it('should add unique values to the set with custom compare function', () => {
+            const set = new HashSet<Comparable>(null, (a, b) => a?.value === b?.value);
+            const value1 = new Comparable(1);
+            const value2 = new Comparable("1");
+
+            set.add(value1);
+            set.add(value2);
+
+            expect(set.length).toBe(2);
+            expect(set.has(value1)).toBe(true);
+            expect(set.has(value2)).toBe(true);
+        });
+
+        it('should not add duplicate values to the set with custom compare function', () => {
+            const set = new HashSet<Comparable>(null, (a, b) => a?.value == b?.value);
+            const value1 = new Comparable(1);
+            const value2 = new Comparable("1");
+
+            set.add(value1);
+            set.add(value2);
+
+            expect(set.length).toBe(1);
+            expect(set.has(value1)).toBe(true);
+            expect(set.has(value2)).toBe(true);
+            expect(set.add(value2)).toStrictEqual(value1);
+        });
+    });
+
+    describe("get", () => {
+        it('should retrieve values from the set', () => {
+            const set = new HashSet<Comparable>();
+            const value1 = new Comparable(1);
+            const value2 = new Comparable(2);
+
+            set.add(value1);
+            set.add(value2);
+
+            expect(set.get(value1)).toBe(value1);
+            expect(set.get(value2)).toBe(value2);
+        });
+
+        it('should return null for non-existing values', () => {
+            const set = new HashSet<Comparable>();
+            const value1 = new Comparable(1);
+            const value2 = new Comparable(2);
+
+            set.add(value1);
+
+            expect(set.get(value2)).toBe(null);
+        });
+    });
+
+    describe("values", () => {
+        it('should return all values in the set', () => {
+            const set = new HashSet<Comparable>();
+            const value1 = new Comparable(1);
+            const value2 = new Comparable(2);
+
+            set.add(value1);
+            set.add(value2);
+
+            const values = set.values();
+
+            expect(values.length).toBe(2);
+            expect(values).toContain(value1);
+            expect(values).toContain(value2);
+        });
+
+        it('should return empty array when set is empty', () => {
+            const set = new HashSet<Comparable>();
+
+            const values = set.values();
+
+            expect(values.length).toBe(0);
+        });
+    });
+
+    describe("toString", () => {
+        it('should convert the set to a string', () => {
+            const set = new HashSet<Comparable>();
+
+            const value1 = new Comparable(1);
+            const value2 = new Comparable(2);
+
+            set.add(value1);
+            set.add(value2);
+
+            const str = set.toString();
+
+            expect(str).toBe('[1, 2]');
+        });
+    });
+});


### PR DESCRIPTION
**Note: _this is a work in progress PR_**

### Description
The goal of this PR is to improve performance of the standard HashSet and HashMap collections in antlr4ng. Some grammars more often hit the HashSet length method to validate if the cache is empty or not. Currently the calculation of the HashSet size is done at the moment when the property is accessed using a `Array.reduce` method. For bigger HashSets this can be an expensive calculation which can be avoided by tracking the size when ever new items are added into the HashSet making accessing the size n(1) operation.

To validate the correctness of the changes in this PR new unit tests are added that test if the basic operations of the HashSet produce the expected results and will also help validate future changes do not break the hashset.

Additionally ICompareable and Hash and Equals function definitions are now templatable allowing the HashSet to specify Value type and the HashMap the Key type as comparable objects. This will provide static type checks to classes that override the default equals or hash methods of the HashMap and HashSet collection types.

### Tasks
- [x] Update HashSet
- [x] Write unit tests for HashSet
- [ ] Update HashMap
- [ ] Write unit tests for HashMap
- [ ] Collect performance data
- [ ] Run Java Runtime Tests