### PR TITLE
Generate sourcemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "tsc": "tsc --watch",
         "build": "npm run generate-test-parsers && tsc && npm run build-cjs && npm run build-mjs",
         "build-minified": "npm run generate-test-parsers && tsc && npm run build-cjs-minified && npm run build-mjs-minified",
-        "build-bundle": "esbuild ./src/index.js --main-fields=module,main --bundle --target=esnext",
+        "build-bundle": "esbuild ./src/index.js --main-fields=module,main --bundle --sourcemap --target=esnext",
         "build-mjs": "npm run build-bundle -- --outfile=dist/index.mjs --format=esm",
         "build-mjs-minified": "npm run build-mjs -- --minify",
         "build-cjs": "npm run build-bundle -- --outfile=dist/index.cjs --format=cjs",


### PR DESCRIPTION
Somehow generated cjs/mjs bundles contain 

```
//# sourceMappingURL=index.mjs.map
```

line, whereas the actual sourcemap file is not included.

When using CRA (Webpack), this results in the following warning (see https://github.com/facebook/create-react-app/pull/11752)

> WARNING in ./node_modules/antlr4ng/dist/index.mjs
Module Warning (from ./node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/Users/nash/projects/my-project/node_modules/antlr4ng/dist/index.mjs.map' file: Error: ENOENT: no such file or directory, open '/Users/nash/projects/my-project/node_modules/antlr4ng/dist/index.mjs.map'

To fix that we have either to make sure the hint line is not there, or actually generate sourcemaps. I think latter is more useful.