### PR TITLE
build: add --keep-names option to build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "tsc": "tsc --watch",
         "build": "npm run generate-test-parsers && tsc && npm run build-cjs && npm run build-mjs",
         "build-minified": "npm run generate-test-parsers && tsc && npm run build-cjs-minified && npm run build-mjs-minified",
-        "build-bundle": "esbuild ./src/index.js --main-fields=module,main --bundle --target=esnext",
+        "build-bundle": "esbuild ./src/index.js --main-fields=module,main --bundle --target=esnext --keep-names",
         "build-mjs": "npm run build-bundle -- --outfile=dist/index.mjs --format=esm",
         "build-mjs-minified": "npm run build-mjs -- --minify",
         "build-cjs": "npm run build-bundle -- --outfile=dist/index.cjs --format=cjs",


### PR DESCRIPTION
To Resoved https://github.com/mike-lischke/antlr4ng/issues/38

## What's changed
Enabling [ `--keep-names`](https://esbuild.github.io/api/#keep-names)  option will change the bundle, as shown below:
1. Two new lines of code have been added to the file header, which are used to keep the name of the class or function
    ```javascript
    var __defProp = Object.defineProperty;
    var __name = (target, value) => __defProp(target, "name", { value, configurable: true });
    ```

2. A static methods will be added to all classes(in the case of ParseTreeWalker):
    ```javascript
    var ParseTreeWalker = class _ParseTreeWalker {
      static {
        __name(this, "ParseTreeWalker");
      }
      // ...
     }
    ```