### PR TITLE
Change ESM build to generate modules for each input file for better treeshaking

### DIFF
--- a/build/build-esm.mjs
+++ b/build/build-esm.mjs
@@ -1,0 +1,141 @@
+import * as esbuild from "esbuild";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+// --------------------------------------------------------------------------
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const srcFolder = "src";
+const distFolder = "dist/esm";
+
+const projectRoot = path.dirname(__dirname);
+const srcRoot = path.join(projectRoot, srcFolder);
+
+// --------------------------------------------------------------------------
+
+const params = process.argv.slice(2);
+// console.debug("[process.argv]", params);
+
+// extract flags from CLI arguments (simple toggle flags, no arguments allowed)
+// https://esbuild.github.io/api/#source-maps
+const sourcemap = params.includes("--sourcemap");
+// https://esbuild.github.io/api/#metafile
+const metafile = params.includes("--metafile");
+
+// remove any flags so that filename will be left
+const paramsWithoutFlags = params.filter((param) => !param.startsWith("--"));
+
+// input file
+const input = paramsWithoutFlags.length > 0 ? paramsWithoutFlags[0] : "./src/index.js";
+// output folder (based on input file)
+const outputDir = outputDirForInput(input);
+
+function outputDirForInput(input) {
+  // absolute file path
+  const absInput = path.resolve(input);
+  // compute relative path based on input/source directory
+  const relInputToSrc = path.relative(srcRoot, absInput);
+  // compute relative path for output/dist directory
+  return path.join(distFolder, path.dirname(relInputToSrc));
+}
+
+// --------------------------------------------------------------------------
+
+const defaultBuildOptions = {
+  bundle: true,
+  outdir: outputDir,
+  target: "esnext",
+  format: "esm",
+  keepNames: true,
+  mainFields: ["module", "main"],
+};
+
+if (sourcemap) {
+  Object.assign(defaultBuildOptions, { sourcemap: "external" });
+}
+if (metafile) {
+  Object.assign(defaultBuildOptions, { metafile: true });
+}
+
+// --------------------------------------------------------------------------
+
+// plugin that will start a new build for each imported filename
+
+const splitFilesPluginSeen = new Set();
+
+const splitFilesPlugin = {
+  name: "split-files",
+  setup(build) {
+    const options = build.initialOptions;
+
+    build.onResolve({ filter: /.*/ }, async (args) => {
+      // console.debug("[split-files][onResolve][args]", args);
+
+      // do nothing for "entry-point"
+      if (args.kind === "entry-point") return;
+      // check for supported processing
+      if (args.kind !== "import-statement") {
+        throw new Error(`Unknown import path type: "${args.kind}", expected "import-statement"`);
+      }
+
+      // this should now only be for "import-statement"
+      const file = path.join(args.resolveDir, args.path);
+
+      // only process (build) file once, then skip
+      if (!splitFilesPluginSeen.has(file)) {
+        splitFilesPluginSeen.add(file);
+
+        // compute input and output names
+        const relInput = "./" + path.relative(projectRoot, file);
+        const relOutput = outputDirForInput(file);
+
+        // run build for imported file as new entry-point
+        // console.debug("[split-files][onResolve] build '%s' to '%s'", relInput, relOutput);
+        await runBuild(relInput, { ...options, outdir: relOutput });
+      }
+
+      // set to external, so it will not be bundled
+      return { external: true };
+    });
+  },
+};
+
+Object.assign(defaultBuildOptions, { plugins: [splitFilesPlugin] });
+
+// --------------------------------------------------------------------------
+
+const metafileAggregated = { inputs: {}, outputs: {} }
+
+console.log(`Start build with "${input}" to "${distFolder}"`);
+if (sourcemap) { console.log(`  - Will generate source maps`) };
+if (metafile) { console.log(`  - Will generate metafile for bundle report`) };
+
+console.time("Took");
+
+// start recursive split bundling build
+await runBuild(input, defaultBuildOptions);
+
+if (metafile) {
+  fs.writeFileSync(path.join(distFolder, "meta.json"), JSON.stringify(metafileAggregated))
+}
+
+console.timeEnd("Took");
+
+// --------------------------------------------------------------------------
+
+async function runBuild(input, options) {
+  const result = await esbuild.build({
+    ...options,
+    entryPoints: [input],
+    // write: false,
+    metafile: true,
+  });
+
+  if (result.metafile) {
+    Object.assign(metafileAggregated.inputs, result.metafile.inputs)
+    Object.assign(metafileAggregated.outputs, result.metafile.outputs)
+  }
+}

--- a/build/build-esm.mjs
+++ b/build/build-esm.mjs
@@ -1,5 +1,5 @@
 import * as esbuild from "esbuild";
-import fs from "fs";
+import { singleModulesPlugin } from "esbuild-plugin-single-modules";
 import path from "path";
 import { fileURLToPath } from "url";
 
@@ -9,7 +9,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const srcFolder = "src";
-const distFolder = "dist/esm";
+const distFolder = "dist";
 
 const projectRoot = path.dirname(__dirname);
 const srcRoot = path.join(projectRoot, srcFolder);
@@ -17,13 +17,10 @@ const srcRoot = path.join(projectRoot, srcFolder);
 // --------------------------------------------------------------------------
 
 const params = process.argv.slice(2);
-// console.debug("[process.argv]", params);
 
 // extract flags from CLI arguments (simple toggle flags, no arguments allowed)
 // https://esbuild.github.io/api/#source-maps
 const sourcemap = params.includes("--sourcemap");
-// https://esbuild.github.io/api/#metafile
-const metafile = params.includes("--metafile");
 
 // remove any flags so that filename will be left
 const paramsWithoutFlags = params.filter((param) => !param.startsWith("--"));
@@ -44,98 +41,28 @@ function outputDirForInput(input) {
 
 // --------------------------------------------------------------------------
 
-const defaultBuildOptions = {
-  bundle: true,
+const options = {
+  entryPoints: [input],
   outdir: outputDir,
   target: "esnext",
   format: "esm",
+  outExtension: { '.js': '.mjs' },
+  // resolveExtensions: ['.ts', '.js', '.mjs'],
+  bundle: true,
   keepNames: true,
+  logLevel: "info",
   mainFields: ["module", "main"],
+  plugins: [singleModulesPlugin({ numLevelsInputPathToDrop: 1, transformImportExtensions: true })]
 };
 
 if (sourcemap) {
-  Object.assign(defaultBuildOptions, { sourcemap: "external" });
-}
-if (metafile) {
-  Object.assign(defaultBuildOptions, { metafile: true });
+  Object.assign(options, { sourcemap: "external" });
 }
 
 // --------------------------------------------------------------------------
-
-// plugin that will start a new build for each imported filename
-
-const splitFilesPluginSeen = new Set();
-
-const splitFilesPlugin = {
-  name: "split-files",
-  setup(build) {
-    const options = build.initialOptions;
-
-    build.onResolve({ filter: /.*/ }, async (args) => {
-      // console.debug("[split-files][onResolve][args]", args);
-
-      // do nothing for "entry-point"
-      if (args.kind === "entry-point") return;
-      // check for supported processing
-      if (args.kind !== "import-statement") {
-        throw new Error(`Unknown import path type: "${args.kind}", expected "import-statement"`);
-      }
-
-      // this should now only be for "import-statement"
-      const file = path.join(args.resolveDir, args.path);
-
-      // only process (build) file once, then skip
-      if (!splitFilesPluginSeen.has(file)) {
-        splitFilesPluginSeen.add(file);
-
-        // compute input and output names
-        const relInput = "./" + path.relative(projectRoot, file);
-        const relOutput = outputDirForInput(file);
-
-        // run build for imported file as new entry-point
-        // console.debug("[split-files][onResolve] build '%s' to '%s'", relInput, relOutput);
-        await runBuild(relInput, { ...options, outdir: relOutput });
-      }
-
-      // set to external, so it will not be bundled
-      return { external: true };
-    });
-  },
-};
-
-Object.assign(defaultBuildOptions, { plugins: [splitFilesPlugin] });
-
-// --------------------------------------------------------------------------
-
-const metafileAggregated = { inputs: {}, outputs: {} }
 
 console.log(`Start build with "${input}" to "${distFolder}"`);
-if (sourcemap) { console.log(`  - Will generate source maps`) };
-if (metafile) { console.log(`  - Will generate metafile for bundle report`) };
 
 console.time("Took");
-
-// start recursive split bundling build
-await runBuild(input, defaultBuildOptions);
-
-if (metafile) {
-  fs.writeFileSync(path.join(distFolder, "meta.json"), JSON.stringify(metafileAggregated))
-}
-
+await esbuild.build(options);
 console.timeEnd("Took");
-
-// --------------------------------------------------------------------------
-
-async function runBuild(input, options) {
-  const result = await esbuild.build({
-    ...options,
-    entryPoints: [input],
-    // write: false,
-    metafile: true,
-  });
-
-  if (result.metafile) {
-    Object.assign(metafileAggregated.inputs, result.metafile.inputs)
-    Object.assign(metafileAggregated.outputs, result.metafile.outputs)
-  }
-}

--- a/build/build-esm.mjs
+++ b/build/build-esm.mjs
@@ -1,65 +1,27 @@
 import * as esbuild from "esbuild";
 import { singleModulesPlugin } from "esbuild-plugin-single-modules";
-import path from "path";
-import { fileURLToPath } from "url";
 
-// --------------------------------------------------------------------------
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const srcFolder = "src";
+const input = "./src/index.js";
 const distFolder = "dist";
-
-const projectRoot = path.dirname(__dirname);
-const srcRoot = path.join(projectRoot, srcFolder);
-
-// --------------------------------------------------------------------------
-
-const params = process.argv.slice(2);
-
-// extract flags from CLI arguments (simple toggle flags, no arguments allowed)
-// https://esbuild.github.io/api/#source-maps
-const sourcemap = params.includes("--sourcemap");
-
-// remove any flags so that filename will be left
-const paramsWithoutFlags = params.filter((param) => !param.startsWith("--"));
-
-// input file
-const input = paramsWithoutFlags.length > 0 ? paramsWithoutFlags[0] : "./src/index.js";
-// output folder (based on input file)
-const outputDir = outputDirForInput(input);
-
-function outputDirForInput(input) {
-  // absolute file path
-  const absInput = path.resolve(input);
-  // compute relative path based on input/source directory
-  const relInputToSrc = path.relative(srcRoot, absInput);
-  // compute relative path for output/dist directory
-  return path.join(distFolder, path.dirname(relInputToSrc));
-}
-
-// --------------------------------------------------------------------------
 
 const options = {
   entryPoints: [input],
-  outdir: outputDir,
+  outdir: distFolder,
   target: "esnext",
   format: "esm",
-  outExtension: { '.js': '.mjs' },
-  // resolveExtensions: ['.ts', '.js', '.mjs'],
-  bundle: true,
+  // sourcemap: "external", // disabled if not required
+  outExtension: { ".js": ".mjs" }, // file extension for modules
+  bundle: true, // required for singleModulesPlugin to work
   keepNames: true,
-  logLevel: "info",
+  logLevel: "info", // output a few esbuild infos
   mainFields: ["module", "main"],
-  plugins: [singleModulesPlugin({ numLevelsInputPathToDrop: 1, transformImportExtensions: true })]
+  plugins: [
+    singleModulesPlugin({
+      numLevelsInputPathToDrop: 1, // remove "src/" path segment from inputs
+      transformImportExtensions: true, // convert import extensions according to outExtension
+    }),
+  ],
 };
-
-if (sourcemap) {
-  Object.assign(options, { sourcemap: "external" });
-}
-
-// --------------------------------------------------------------------------
 
 console.log(`Start build with "${input}" to "${distFolder}"`);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
                 "@typescript-eslint/parser": "7.18.0",
                 "@vitest/coverage-v8": "^2.1.3",
                 "esbuild": "0.23.0",
+                "esbuild-plugin-single-modules": "^1.0.0",
                 "eslint": "8.57.0",
                 "eslint-plugin-import": "2.29.1",
                 "eslint-plugin-jsdoc": "48.10.2",
@@ -2477,6 +2478,16 @@
                 "@esbuild/win32-arm64": "0.23.0",
                 "@esbuild/win32-ia32": "0.23.0",
                 "@esbuild/win32-x64": "0.23.0"
+            }
+        },
+        "node_modules/esbuild-plugin-single-modules": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/esbuild-plugin-single-modules/-/esbuild-plugin-single-modules-1.0.0.tgz",
+            "integrity": "sha512-LZQuX7p8aMPFymxIIHQmWjR6rB8l2RuVSvFlGQt/MCa2UDzdU8h2Pgr9+tHlcHlhKj9to5ELMIv6YlvhaZwgKw==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "esbuild": ">=0.23.0"
             }
         },
         "node_modules/escape-string-regexp": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     },
     "scripts": {
         "prepublishOnly": "npm run build && npm run test",
-        "build": "tsc && npm run build-cjs && npm run build-mjs",
+        "build": "tsc && npm run build-cjs && npm run build-mjs && npm run build-esm",
         "build-with-maps": "tsc && npm run build-mjs -- --sourcemap",
         "build-and-test": "npm run build && npm run test",
         "test": "vitest run --no-watch --no-coverage",
@@ -55,6 +55,7 @@
         "build-bundle": "esbuild ./src/index.js --main-fields=module,main --bundle --target=esnext --keep-names",
         "build-mjs": "npm run build-bundle -- --outfile=dist/index.mjs --format=esm",
         "build-cjs": "npm run build-bundle -- --outfile=dist/index.cjs --format=cjs",
+        "build-esm": "node build/build-esm.mjs ./src/index.js",
         "generate-xpath-lexer": "node cli/index.js -Dlanguage=TypeScript -o src/tree/xpath/generated -no-visitor -no-listener -Xexact-output-dir src/tree/xpath/XPathLexer.g4",
         "profile benchmarks": "node --no-warnings --experimental-vm-modules --prof --loader ts-node/esm tests/benchmarks/run-benchmarks.ts",
         "process profile tick file": " node --prof-process isolate-0x140008000-94064-v8.log > processed.txt"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "@typescript-eslint/parser": "7.18.0",
         "@vitest/coverage-v8": "2.1.3",
         "esbuild": "0.23.0",
+        "esbuild-plugin-single-modules": "^1.0.0",
         "eslint": "8.57.0",
         "eslint-plugin-import": "2.29.1",
         "eslint-plugin-jsdoc": "48.10.2",
@@ -43,7 +44,7 @@
     },
     "scripts": {
         "prepublishOnly": "npm run build && npm run test",
-        "build": "tsc && npm run build-cjs && npm run build-mjs && npm run build-esm",
+        "build": "tsc && npm run build-cjs && npm run build-esm",
         "build-with-maps": "tsc && npm run build-mjs -- --sourcemap",
         "build-and-test": "npm run build && npm run test",
         "test": "vitest run --no-watch --no-coverage",


### PR DESCRIPTION
Implementing https://github.com/mike-lischke/antlr4ng/issues/103

This pull requests improves tree-shaking for using `antlr4ng` with ESM modules.

It add a `esbuild` script `build/build-esm.mjs` that will traverse the import tree from a given input script and runs the ESM build with `esbuild` for each file separately. This will generate for each source input file an output file.

The `package.json` configuration includes the `"sideEffects": false` statement.
The original single bundle `index.mjs` will now contain imports to each module that `antlr4ng` requires not not be a single bundle. All the ESM/ES6 module files have the `.mjs` extension.